### PR TITLE
feat(HF-8): add Clerk identity layer (HF-10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ next-env.d.ts
 
 # implemenation plan file
 implementation_plan.md
+
+# clerk configuration (can include secrets)
+/.clerk/

--- a/app/(auth)/sign-in/[[...sign-in]]/page.tsx
+++ b/app/(auth)/sign-in/[[...sign-in]]/page.tsx
@@ -1,0 +1,9 @@
+import { SignIn } from "@clerk/nextjs";
+
+export default function SignInPage() {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-zinc-950">
+      <SignIn />
+    </main>
+  );
+}

--- a/app/(auth)/sign-up/[[...sign-up]]/page.tsx
+++ b/app/(auth)/sign-up/[[...sign-up]]/page.tsx
@@ -1,0 +1,9 @@
+import { SignUp } from "@clerk/nextjs";
+
+export default function SignUpPage() {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-zinc-950">
+      <SignUp />
+    </main>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,11 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import {
+  ClerkProvider,
+  SignInButton,
+  UserButton,
+  Show,
+} from "@clerk/nextjs";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -23,12 +29,27 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} bg-zinc-950 antialiased`}
-      >
-        {children}
-      </body>
-    </html>
+    // ClerkProvider is outermost — above <html> — to eliminate FOUC
+    <ClerkProvider>
+      <html lang="en">
+        <body
+          className={`${geistSans.variable} ${geistMono.variable} bg-zinc-950 antialiased`}
+        >
+          <header className="flex items-center justify-end px-6 py-3 border-b border-zinc-800">
+            <Show when="signed-out">
+              <SignInButton>
+                <button className="rounded-md bg-white px-4 py-1.5 text-sm font-medium text-black hover:bg-zinc-200 transition-colors cursor-pointer">
+                  Sign In
+                </button>
+              </SignInButton>
+            </Show>
+            <Show when="signed-in">
+              <UserButton />
+            </Show>
+          </header>
+          {children}
+        </body>
+      </html>
+    </ClerkProvider>
   );
 }

--- a/implementation_plan.md
+++ b/implementation_plan.md
@@ -1,57 +1,124 @@
-# HF-6: Initial Vercel Deployment
+# HF-8 (Jira: HF-10): Identity Layer (Clerk Integration)
 
-Ship the Walking Skeleton to production and confirm the live URL can talk to MongoDB Atlas.
+> **Note:** Due to Jira's auto-increment, your HF-8 (Identity Layer) was assigned key **HF-10**. Plan references both for clarity.
 
 ---
 
-## Steps
+## Proposed Changes
 
-### 1 — Push & Open a PR
+### Dependencies
 
 ```bash
-git push origin HF-2-Walking-Skeleton-Core-Infrastructure-Base-Architecture
+npm install @clerk/nextjs
 ```
 
-Open a PR on GitHub → `main`. Title: `feat: Walking Skeleton (HF-2)`.
+### `.env.local` additions
+
+```bash
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_...
+CLERK_SECRET_KEY=sk_test_...
+```
+
+Add both to Vercel env vars as well (HF-12 catch-up).
 
 ---
 
-### 2 — Import to Vercel
+### [middleware.ts](file:///media/Hybrid/Coding/habitflow/middleware.ts) [NEW]
 
-1. Go to [vercel.com/new](https://vercel.com/new)
-2. Import the `HabitFlow` GitHub repository.
-3. Framework preset: **Next.js** (auto-detected).
-4. Leave build & output settings as defaults.
+```ts
+import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 
----
+const isPublicRoute = createRouteMatcher(["/", "/sign-in(.*)", "/sign-up(.*)"]);
 
-### 3 — Add Environment Variables
+export default clerkMiddleware((auth, req) => {
+  if (!isPublicRoute(req)) auth().protect();
+});
 
-In the Vercel project → **Settings → Environment Variables**, add:
-
-| Key | Value | Environments |
-|-----|-------|-------------|
-| `MONGODB_URI` | Your Atlas connection string | Production, Preview, Development |
-
-> [!IMPORTANT]
-> Ensure the Atlas cluster **Network Access** list includes `0.0.0.0/0` (allow all IPs) for Vercel's dynamic IP pool, or use a Vercel-specific IP allowlist.
+export const config = {
+  matcher: ["/((?!_next|.*\\..*).*)"],
+};
+```
 
 ---
 
-### 4 — Deploy & Verify
+### [app/layout.tsx](file:///media/Hybrid/Coding/habitflow/app/layout.tsx) [MODIFY]
 
-- Trigger a deploy (automatic on PR merge, or manual via Vercel dashboard).
-- Open the live URL → page loads with **"HabitFlow — DB Proof"**.
-- Click **+ Test DB** → task appears in the list.
-- Check Vercel **Function Logs** → `✅ MongoDB connected` present, no errors.
+Wrap the root layout in `ClerkProvider` and add sign-in/sign-out UI:
+
+```tsx
+import { ClerkProvider, SignInButton, SignedIn, SignedOut, UserButton } from "@clerk/nextjs";
+
+// Inside RootLayout return:
+<ClerkProvider>
+  <html lang="en">
+    <body ...>
+      <header>
+        <SignedOut><SignInButton /></SignedOut>
+        <SignedIn><UserButton /></SignedIn>
+      </header>
+      {children}
+    </body>
+  </html>
+</ClerkProvider>
+```
+
+---
+
+### [lib/actions/task.actions.ts](file:///media/Hybrid/Coding/habitflow/lib/actions/task.actions.ts) [MODIFY]
+
+Replace hardcoded `"test-user"` with `auth().userId` from Clerk:
+
+```ts
+import { auth } from "@clerk/nextjs/server";
+
+export async function createTask(): Promise<void> {
+  const { userId } = await auth();
+  if (!userId) throw new Error("401 Unauthorized");
+  // ...
+  await Task.create({ userId, title: "My first HabitFlow task", priority: "medium" });
+  revalidatePath("/");
+}
+
+export async function getTasks(): Promise<TaskDTO[]> {
+  const { userId } = await auth();
+  if (!userId) return [];
+  // ...
+  const tasks = await Task.find({ userId }).lean<ITask[]>();
+  // ...
+}
+```
+
+---
+
+### [app/(auth)/sign-in/[[...sign-in]]/page.tsx](file:///media/Hybrid/Coding/habitflow/app/(auth)/sign-in/[[...sign-in]]/page.tsx) [NEW]
+
+```tsx
+import { SignIn } from "@clerk/nextjs";
+export default function SignInPage() {
+  return <SignIn />;
+}
+```
+
+### [app/(auth)/sign-up/[[...sign-up]]/page.tsx](file:///media/Hybrid/Coding/habitflow/app/(auth)/sign-up/[[...sign-up]]/page.tsx) [NEW]
+
+```tsx
+import { SignUp } from "@clerk/nextjs";
+export default function SignUpPage() {
+  return <SignUp />;
+}
+```
 
 ---
 
 ## Verification Plan
 
-| Check | Expected |
-|-------|----------|
-| Live URL loads | Page renders without 500 error |
-| `+ Test DB` button | New task appears after click |
-| Vercel Function Logs | `✅ MongoDB connected` on first cold start |
-| Atlas dashboard | `habitflow.tasks` collection has documents |
+1. `npm run dev` → visit `/` — `Sign In` button visible in header.
+2. Click **Sign In** → Clerk-hosted modal appears.
+3. Create an account → redirected back to `/`.
+4. `UserButton` avatar visible in header.
+5. Visit `/dashboard` while signed out → redirected to sign-in.
+6. Click **+ Test DB** → task created; check Atlas — `userId` matches Clerk user ID (not `"test-user"`).
+
+```bash
+npx tsc --noEmit   # 0 errors expected
+```

--- a/lib/actions/task.actions.ts
+++ b/lib/actions/task.actions.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { auth } from "@clerk/nextjs/server";
 import { revalidatePath } from "next/cache";
 import { connectDB } from "@/lib/db";
 import Task, { ITask } from "@/models/Task";
@@ -13,27 +14,31 @@ export type TaskDTO = {
 };
 
 export async function createTask(): Promise<void> {
+  const { userId } = await auth(); // server-side only — ID-spoofing proof
+  if (!userId) throw new Error("401 Unauthorized");
+
   if (!process.env.MONGODB_URI) {
-    throw new Error(
-      "MONGODB_URI is not set. Restart the dev server after updating .env.local."
-    );
+    throw new Error("MONGODB_URI is not set. Restart the dev server after updating .env.local.");
   }
 
   try {
     await connectDB();
     await Task.create({
-      userId: "test-user",
-      title: "My first HabitFlow task",
+      userId,
+      title: "My HabitFlow task",
       priority: "medium",
     });
-    revalidatePath("/"); // bust cache so the new task appears immediately
+    revalidatePath("/");
   } catch (err) {
     console.error("[createTask] Failed:", err);
-    throw err; // re-throw so the form surface can handle it
+    throw err;
   }
 }
 
 export async function getTasks(): Promise<TaskDTO[]> {
+  const { userId } = await auth(); // server-side only
+  if (!userId) return [];
+
   if (!process.env.MONGODB_URI) {
     console.warn("[getTasks] MONGODB_URI not set — returning empty list.");
     return [];
@@ -41,8 +46,8 @@ export async function getTasks(): Promise<TaskDTO[]> {
 
   try {
     await connectDB();
-    const tasks = await Task.find({ userId: "test-user" }).lean<ITask[]>();
-    // Explicitly serialize ObjectIds/Dates → strings to avoid Next.js POJO errors
+    const tasks = await Task.find({ userId }).lean<ITask[]>();
+    // Explicitly serialize ObjectIds/Dates → strings (Next.js POJO requirement)
     return tasks.map((t) => ({
       _id: String(t._id),
       title: t.title,
@@ -51,6 +56,6 @@ export async function getTasks(): Promise<TaskDTO[]> {
     }));
   } catch (err) {
     console.error("[getTasks] Failed:", err);
-    return []; // safe fallback — UI shows empty list instead of crashing
+    return [];
   }
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,19 @@
+import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
+
+const isPublicRoute = createRouteMatcher(["/", "/sign-in(.*)", "/sign-up(.*)"]);
+
+export default clerkMiddleware(async (auth, req) => {
+  if (!isPublicRoute(req)) {
+    const { userId, redirectToSignIn } = await auth();
+    if (!userId) return redirectToSignIn({ returnBackUrl: req.url });
+  }
+});
+
+export const config = {
+  // Ignores _next internals and all static asset file extensions.
+  // Catches all app routes including nested /dashboard/** paths.
+  matcher: [
+    "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
+    "/(api|trpc)(.*)",
+  ],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "habitflow",
       "version": "0.1.0",
       "dependencies": {
+        "@clerk/nextjs": "^7.0.1",
         "mongoose": "^9.2.4",
         "next": "16.1.6",
         "react": "19.2.3",
@@ -275,6 +276,87 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@clerk/backend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.0.1.tgz",
+      "integrity": "sha512-U5E+KpNlFlaJRdpOoOltIV8o1YjTWw5affsugEb/kIvGceSP6SzvNEBr/TnCY+2yu87Vq22ShEycpQBlse2Bkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^4.0.0",
+        "standardwebhooks": "^1.0.0",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      }
+    },
+    "node_modules/@clerk/nextjs": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-7.0.1.tgz",
+      "integrity": "sha512-sm5vpQkVUpTWFGe6k4wELL4zTve4JK5IWd8epBj6x4fBAWJMqtC3QeWrvaI7Sl8Ef/0STOM41FcwsVtVMk4v9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/backend": "^3.0.1",
+        "@clerk/react": "^6.0.1",
+        "@clerk/shared": "^4.0.0",
+        "server-only": "0.0.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "next": "^15.2.8 || ^15.3.8 || ^15.4.10 || ^15.5.9 || ^15.6.0-0 || ^16.0.10 || ^16.1.0-0",
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      }
+    },
+    "node_modules/@clerk/react": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@clerk/react/-/react-6.0.1.tgz",
+      "integrity": "sha512-zq6vfH7Yiul4PPxUmyl/iW6CZbIzxfHvhXLxZK9zbqHQEy9xDlIQirhWIiHucBqMWTJruudY5KCV5WBe2xmfww==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^4.0.0",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      }
+    },
+    "node_modules/@clerk/shared": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.0.0.tgz",
+      "integrity": "sha512-Z3QhVud7FM9SBgSGxyUdC+nDg6vro+5zJ5gDO1To3FDzRLWKW4xIGd5y8UBqWZMMMHWaSDiZvYlUynb+gs8PnQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.16",
+        "dequal": "2.0.3",
+        "glob-to-regexp": "0.4.1",
+        "js-cookie": "3.0.5",
+        "std-env": "^3.9.0"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@emnapi/core": {
@@ -1303,6 +1385,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -1593,6 +1681,16 @@
         "@tailwindcss/oxide": "4.2.1",
         "postcss": "^8.5.6",
         "tailwindcss": "4.2.1"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.16",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.16.tgz",
+      "integrity": "sha512-MvtWckSVufs/ja463/K4PyJeqT+HMlJWtw6PrCpywznd2NSgO3m4KwO9RqbFqGg6iDE8vVMFWMeQI4Io3eEYww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -2913,6 +3011,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -3660,6 +3767,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -3893,6 +4006,12 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/globals": {
       "version": "14.0.0",
@@ -4562,6 +4681,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {
@@ -5904,6 +6032,12 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
@@ -6139,6 +6273,22 @@
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@clerk/nextjs": "^7.0.1",
     "mongoose": "^9.2.4",
     "next": "16.1.6",
     "react": "19.2.3",


### PR DESCRIPTION
- Install @clerk/nextjs v7
- Add middleware.ts with clerkMiddleware + robust static asset matcher
- Wrap RootLayout in ClerkProvider (outermost, above html) to prevent FOUC
- Add Show when=signed-in/out header with SignInButton + UserButton
- Create app/(auth)/sign-in and sign-up catch-all pages
- Update task.actions.ts: server-side auth(), replace test-user with Clerk userId
- Add 401 guard + MONGODB_URI guard to Server Actions

task HF-10 #done
epic HF-7