### PR TITLE
Implement PWA Install Prompt with iOS Guides and Styling Refinements

### DIFF
--- a/components/dashboard/NerveCenterClient.tsx
+++ b/components/dashboard/NerveCenterClient.tsx
@@ -4,10 +4,12 @@ import { useOptimistic, useTransition, useState, useEffect } from "react";
 import { checkOffHabit } from "@/lib/actions/habit.actions";
 import { setTaskCompleted, updateTask } from "@/lib/actions/task.actions";
 import { getDashboardSummary } from "@/lib/actions/summary.actions";
+import { useAutoAnimate } from "@formkit/auto-animate/react";
 import HabitCarousel from "./HabitCarousel";
 import PriorityTaskList from "./PriorityTaskList";
 import AiIntelligenceSlot from "./AiIntelligenceSlot";
 import WeeklySnapshot from "./WeeklySnapshot";
+import PwaInstallPrompt from "./PwaInstallPrompt";
 import { Activity } from "lucide-react";
 import TaskModal from "@/components/tasks/TaskModal";
 import HabitAnalyticsDrawer from "@/components/habits/HabitAnalyticsDrawer";
@@ -38,6 +40,7 @@ export interface DashboardSummary {
 }
 
 export default function NerveCenterClient({ initialData }: { initialData: DashboardSummary }) {
+  const [parentRef] = useAutoAnimate();
   const [overrideSummary, setOverrideSummary] = useState<DashboardSummary | null>(null);
   const activeData = overrideSummary || initialData;
   const [isPending, startTransition] = useTransition();
@@ -132,7 +135,10 @@ export default function NerveCenterClient({ initialData }: { initialData: Dashbo
   const isDoubleEmpty = optHabits.length === 0 && optTasks.length === 0;
 
   return (
-    <div className="p-6 md:p-8 space-y-8 max-w-5xl mx-auto overflow-x-hidden md:overflow-x-visible">
+    <div ref={parentRef} className="p-6 md:p-8 space-y-8 max-w-5xl mx-auto overflow-x-hidden md:overflow-x-visible">
+      {/* PWA Install Promotion Banner */}
+      <PwaInstallPrompt />
+
       {/* Greeting Header */}
       <div className="space-y-1">
         <h1 className="text-3xl font-bold tracking-tight text-white">{activeData.greeting}</h1>

--- a/components/dashboard/PwaInstallPrompt.tsx
+++ b/components/dashboard/PwaInstallPrompt.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Share, PlusSquare, X, Download } from "lucide-react";
+
+export default function PwaInstallPrompt() {
+  const [deferredPrompt, setDeferredPrompt] = useState<any>(null);
+  const [showPrompt, setShowPrompt] = useState(false);
+  const [isIOS, setIsIOS] = useState(false);
+
+  useEffect(() => {
+    // 1. Check if already installed / standalone mode
+    const isStandalone = 
+      window.matchMedia("(display-mode: standalone)").matches || 
+      (window.navigator as any).standalone === true;
+
+    if (isStandalone) return;
+
+    // 2. Check if dismissed previously
+    const isDismissed = localStorage.getItem("veyrflow_install_prompt_dismissed") === "true";
+    if (isDismissed) return;
+
+    // 3. Detect iOS Safari/other browsers
+    const ua = window.navigator.userAgent;
+    const iOS = /iPad|iPhone|iPod/.test(ua) && !(window as any).MSStream;
+    setIsIOS(iOS);
+
+    if (iOS) {
+      // Show instructional tip card for iOS users
+      setShowPrompt(true);
+      return;
+    }
+
+    // 4. Listen for native browser PWA install prompt event (Chrome/Android/Edge)
+    const handler = (e: Event) => {
+      e.preventDefault();
+      setDeferredPrompt(e);
+      setShowPrompt(true);
+    };
+
+    window.addEventListener("beforeinstallprompt", handler);
+
+    // If app installed successfully, hide the prompt
+    const installedHandler = () => {
+      setShowPrompt(false);
+    };
+    window.addEventListener("appinstalled", installedHandler);
+
+    return () => {
+      window.removeEventListener("beforeinstallprompt", handler);
+      window.removeEventListener("appinstalled", installedHandler);
+    };
+  }, []);
+
+  const handleInstallClick = async () => {
+    if (!deferredPrompt) return;
+    deferredPrompt.prompt();
+    const { outcome } = await deferredPrompt.userChoice;
+    if (outcome === "accepted") {
+      setDeferredPrompt(null);
+      setShowPrompt(false);
+    }
+  };
+
+  const handleDismiss = () => {
+    localStorage.setItem("veyrflow_install_prompt_dismissed", "true");
+    setShowPrompt(false);
+  };
+
+  if (!showPrompt) return null;
+
+  return (
+    <div className="relative overflow-hidden bg-zinc-950/80 backdrop-blur-xl border border-indigo-500/20 rounded-2xl p-4 shadow-2xl flex items-center justify-between gap-4">
+      {/* VeyrFlow Dynamic Logo Graphic background element */}
+      <div className="absolute -top-10 -right-10 w-32 h-32 bg-indigo-500/5 blur-2xl rounded-full pointer-events-none" />
+
+      <div className="flex items-start gap-3 relative z-10 flex-1 min-w-0">
+        <div className="p-2.5 rounded-xl bg-indigo-500/10 text-indigo-400 border border-indigo-500/20 shrink-0">
+          <Download size={20} />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h3 className="text-sm font-bold text-zinc-100 tracking-wide">Install VeyrFlow</h3>
+          {isIOS ? (
+            <p className="text-xs text-zinc-400 mt-1 leading-relaxed flex flex-wrap items-center gap-1.5">
+              To install, tap
+              <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-zinc-900 border border-zinc-800 text-zinc-300">
+                <Share size={12} className="text-indigo-400" /> Share
+              </span>
+              below, then select
+              <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-zinc-900 border border-zinc-800 text-zinc-300">
+                Add to Home Screen <PlusSquare size={12} className="text-indigo-400" />
+              </span>
+            </p>
+          ) : (
+            <p className="text-xs text-zinc-400 mt-1 leading-relaxed">
+              Install VeyrFlow on your home screen for a fast, tactile app experience.
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2 relative z-10 shrink-0">
+        {!isIOS && (
+          <button
+            onClick={handleInstallClick}
+            className="px-3.5 py-1.5 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white font-semibold text-xs transition-colors cursor-pointer active:scale-[0.98] transition-transform duration-75 shadow-[0_0_15px_-3px_rgba(99,102,241,0.5)]"
+          >
+            Install
+          </button>
+        )}
+        <button
+          onClick={handleDismiss}
+          className="p-2 rounded-lg border border-zinc-800 bg-zinc-900/60 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-200 transition-colors cursor-pointer active:scale-[0.98] transition-transform duration-75"
+          aria-label="Dismiss install prompt"
+          title="Dismiss"
+        >
+          <X size={14} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/PwaInstallPrompt.tsx
+++ b/components/dashboard/PwaInstallPrompt.tsx
@@ -70,7 +70,7 @@ export default function PwaInstallPrompt() {
   if (!showPrompt) return null;
 
   return (
-    <div className="relative overflow-hidden bg-zinc-950/80 backdrop-blur-xl border border-indigo-500/20 rounded-2xl p-4 shadow-2xl flex items-center justify-between gap-4">
+    <div className="relative overflow-hidden bg-zinc-950/80 backdrop-blur-xl border border-indigo-500/20 rounded-xl p-4 shadow-2xl flex items-center justify-between gap-4">
       {/* VeyrFlow Dynamic Logo Graphic background element */}
       <div className="absolute -top-10 -right-10 w-32 h-32 bg-indigo-500/5 blur-2xl rounded-full pointer-events-none" />
 
@@ -81,15 +81,8 @@ export default function PwaInstallPrompt() {
         <div className="min-w-0 flex-1">
           <h3 className="text-sm font-bold text-zinc-100 tracking-wide">Install VeyrFlow</h3>
           {isIOS ? (
-            <p className="text-xs text-zinc-400 mt-1 leading-relaxed flex flex-wrap items-center gap-1.5">
-              To install, tap
-              <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-zinc-900 border border-zinc-800 text-zinc-300">
-                <Share size={12} className="text-indigo-400" /> Share
-              </span>
-              below, then select
-              <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded bg-zinc-900 border border-zinc-800 text-zinc-300">
-                Add to Home Screen <PlusSquare size={12} className="text-indigo-400" />
-              </span>
+            <p className="text-xs text-zinc-400 mt-1 leading-relaxed flex flex-wrap items-center gap-1">
+              To install, tap <Share size={14} className="inline text-indigo-400 mx-0.5" /> below, then select &apos;Add to Home Screen&apos; <PlusSquare size={14} className="inline text-indigo-400 mx-0.5" />.
             </p>
           ) : (
             <p className="text-xs text-zinc-400 mt-1 leading-relaxed">


### PR DESCRIPTION
This pull request introduces a user-friendly PWA (Progressive Web App) install prompt to the dashboard, encouraging users to install the app on their device for a better experience. It also integrates animation for smoother UI transitions. The main changes are grouped below:

**PWA Install Prompt Feature:**

* Added a new `PwaInstallPrompt` component that detects when to show a PWA installation banner, handles both iOS and Android/Chrome scenarios, and allows users to dismiss the prompt, with dismissal state persisted in `localStorage`. The prompt provides platform-specific instructions and an install button where supported. (`components/dashboard/PwaInstallPrompt.tsx`)
* Integrated the `PwaInstallPrompt` into the main dashboard UI by rendering it at the top of the dashboard page. (`components/dashboard/NerveCenterClient.tsx`)

**UI/UX Improvements:**

* Added the `useAutoAnimate` hook from `@formkit/auto-animate/react` to the dashboard container, enabling smooth animations for UI changes. (`components/dashboard/NerveCenterClient.tsx`) [[1]](diffhunk://#diff-7827a686d13d5c039d1352a599460cfde9d22e78a299761a05c5d813e916e275R7-R12) [[2]](diffhunk://#diff-7827a686d13d5c039d1352a599460cfde9d22e78a299761a05c5d813e916e275R43)