### PR TITLE
feat: Add push notification toggle component and related hooks for managing subscriptions

### DIFF
--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { Shield, Sparkles, Monitor, ArrowUpFromLine, Download, CheckCircle2, Sliders } from "lucide-react";
+import PushNotificationToggle from "@/components/settings/PushNotificationToggle";
 
 export default function SettingsPage() {
   const [deferredPrompt, setDeferredPrompt] = useState<any>(null);
@@ -149,6 +150,9 @@ export default function SettingsPage() {
             </div>
           )}
         </section>
+
+        {/* Card 3: Push Notifications */}
+        <PushNotificationToggle />
       </div>
     </div>
   );

--- a/components/settings/PushNotificationToggle.tsx
+++ b/components/settings/PushNotificationToggle.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { usePushNotifications } from "@/hooks/usePushNotifications";
+import { Bell, BellOff, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+export default function PushNotificationToggle() {
+  const {
+    isSupported,
+    permission,
+    isSubscribed,
+    loading,
+    subscribe,
+    unsubscribe,
+  } = usePushNotifications();
+
+  const handleToggle = async () => {
+    if (loading) return;
+    try {
+      if (isSubscribed) {
+        await unsubscribe();
+        toast.success("Successfully unsubscribed from push notifications.");
+      } else {
+        await subscribe();
+        toast.success("Successfully subscribed to push notifications!");
+      }
+    } catch (err: any) {
+      toast.error(err.message || "An error occurred updating subscription.");
+    }
+  };
+
+  if (!isSupported) {
+    return (
+      <section className="rounded-3xl border border-zinc-800 bg-zinc-950/40 p-6 space-y-4 relative overflow-hidden backdrop-blur-md">
+        <div className="absolute top-0 right-0 w-32 h-32 bg-red-500/5 blur-3xl rounded-full pointer-events-none" />
+        <h2 className="text-lg font-bold text-zinc-100 flex items-center gap-2">
+          <BellOff size={18} className="text-red-400" />
+          Push Notifications
+        </h2>
+        <p className="text-xs text-zinc-400 leading-relaxed">
+          Push notifications are not supported on this browser or device. Ensure you are using a compatible browser like Chrome, Firefox, or Safari, and that your connection is secure (HTTPS).
+        </p>
+      </section>
+    );
+  }
+
+  const isBlocked = permission === "denied";
+
+  return (
+    <section className="rounded-3xl border border-zinc-800 bg-zinc-950/40 p-6 space-y-6 relative overflow-hidden backdrop-blur-md">
+      <div className="absolute top-0 right-0 w-32 h-32 bg-teal-500/5 blur-3xl rounded-full pointer-events-none" />
+      
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-1">
+          <h2 className="text-lg font-bold text-zinc-100 flex items-center gap-2">
+            <Bell size={18} className="text-teal-400" />
+            Push Notifications
+          </h2>
+          <p className="text-xs text-zinc-400 leading-relaxed">
+            Receive reminders and smart summaries of your habits directly on your device.
+          </p>
+        </div>
+
+        {/* Toggle Switch */}
+        <button
+          onClick={handleToggle}
+          disabled={loading || isBlocked}
+          className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-offset-2 focus:ring-offset-zinc-900 ${
+            isSubscribed ? "bg-teal-500" : "bg-zinc-800"
+          } ${loading || isBlocked ? "opacity-50 cursor-not-allowed" : ""}`}
+          aria-label="Toggle push notifications"
+        >
+          <span
+            className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out flex items-center justify-center ${
+              isSubscribed ? "translate-x-5" : "translate-x-0"
+            }`}
+          >
+            {loading && <Loader2 size={12} className="text-zinc-600 animate-spin" />}
+          </span>
+        </button>
+      </div>
+
+      <div className="space-y-2">
+        {isBlocked && (
+          <div className="rounded-2xl border border-red-500/20 bg-red-500/5 p-4 text-xs text-red-300">
+            <strong>Permission Blocked:</strong> Push notifications are blocked by your browser settings. Please reset the notification permission for this site in your browser to enable alerts.
+          </div>
+        )}
+
+        {!isBlocked && isSubscribed && (
+          <div className="rounded-2xl border border-teal-500/20 bg-teal-500/5 p-4 text-xs text-teal-300">
+            <strong>Subscribed:</strong> Your device is registered to receive system updates and reminders.
+          </div>
+        )}
+
+        {!isBlocked && !isSubscribed && (
+          <div className="rounded-2xl border border-zinc-800 bg-zinc-900/20 p-4 text-xs text-zinc-400">
+            Notifications are currently disabled. Toggle the switch above to subscribe.
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/hooks/usePushNotifications.ts
+++ b/hooks/usePushNotifications.ts
@@ -1,0 +1,72 @@
+import { useState, useEffect, useCallback } from "react";
+import { subscribeToPushNotifications, unsubscribeFromPushNotifications } from "@/lib/webPush";
+
+export function usePushNotifications() {
+  const [isSupported, setIsSupported] = useState(false);
+  const [permission, setPermission] = useState<NotificationPermission>("default");
+  const [isSubscribed, setIsSubscribed] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const checkSubscription = useCallback(async () => {
+    if (typeof window === "undefined") return;
+    
+    const supported = "serviceWorker" in navigator && "PushManager" in window;
+    setIsSupported(supported);
+
+    if (supported) {
+      setPermission(Notification.permission);
+      try {
+        const registration = await navigator.serviceWorker.ready;
+        const subscription = await registration.pushManager.getSubscription();
+        setIsSubscribed(!!subscription);
+      } catch (err) {
+        console.error("Error checking push subscription status:", err);
+      }
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    checkSubscription();
+  }, [checkSubscription]);
+
+  const subscribe = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await subscribeToPushNotifications();
+      setIsSubscribed(true);
+      setPermission(Notification.permission);
+    } catch (err: any) {
+      setError(err.message || "Failed to subscribe.");
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const unsubscribe = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await unsubscribeFromPushNotifications();
+      setIsSubscribed(false);
+    } catch (err: any) {
+      setError(err.message || "Failed to unsubscribe.");
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return {
+    isSupported,
+    permission,
+    isSubscribed,
+    loading,
+    error,
+    subscribe,
+    unsubscribe,
+  };
+}

--- a/lib/webPush.ts
+++ b/lib/webPush.ts
@@ -1,0 +1,78 @@
+export function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = "=".repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding)
+    .replace(/\-/g, "+")
+    .replace(/_/g, "/");
+
+  const rawData = window.atob(base64);
+  const outputArray = new Uint8Array(rawData.length);
+
+  for (let i = 0; i < rawData.length; ++i) {
+    outputArray[i] = rawData.charCodeAt(i);
+  }
+  return outputArray;
+}
+
+export async function subscribeToPushNotifications(): Promise<PushSubscription | null> {
+  if (typeof window === "undefined" || !("serviceWorker" in navigator) || !("PushManager" in window)) {
+    throw new Error("Push notifications are not supported on this browser.");
+  }
+
+  const permission = await Notification.requestPermission();
+  if (permission !== "granted") {
+    throw new Error("Notification permission denied.");
+  }
+
+  const registration = await navigator.serviceWorker.ready;
+  const vapidPublicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
+  if (!vapidPublicKey) {
+    throw new Error("VAPID public key is missing from environment variables.");
+  }
+
+  const convertedVapidKey = urlBase64ToUint8Array(vapidPublicKey);
+
+  let subscription = await registration.pushManager.getSubscription();
+  if (!subscription) {
+    subscription = await registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: convertedVapidKey as any,
+    });
+  }
+
+  const response = await fetch("/api/notifications/subscribe", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(subscription),
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to store subscription on server.");
+  }
+
+  return subscription;
+}
+
+export async function unsubscribeFromPushNotifications(): Promise<void> {
+  if (typeof window === "undefined" || !("serviceWorker" in navigator)) {
+    return;
+  }
+  const registration = await navigator.serviceWorker.ready;
+  const subscription = await registration.pushManager.getSubscription();
+  if (subscription) {
+    await subscription.unsubscribe();
+    
+    const response = await fetch("/api/notifications/unsubscribe", {
+      method: "DELETE",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ endpoint: subscription.endpoint }),
+    });
+    
+    if (!response.ok) {
+      throw new Error("Failed to unsubscribe on server.");
+    }
+  }
+}


### PR DESCRIPTION
This pull request adds user-facing support for push notifications in the app's settings, allowing users to subscribe or unsubscribe to notifications directly from the dashboard. The implementation includes a new UI toggle, a custom React hook for managing push notification state, and utility functions for subscribing/unsubscribing and interacting with the server.

**Push Notification Feature Integration:**

* Added a new `PushNotificationToggle` component to the settings page UI, enabling users to manage their push notification subscription status. [[1]](diffhunk://#diff-28714cf45a56641c20fa7fed9a0b7cef7e0cd82b7469fefc28dbcf67b1204c0aR5) [[2]](diffhunk://#diff-28714cf45a56641c20fa7fed9a0b7cef7e0cd82b7469fefc28dbcf67b1204c0aR153-R155) [[3]](diffhunk://#diff-5e1f5890313d5a0771f32914dd7d0c62ba754a383be211c5348d644b0c3decbaR1-R104)
* Implemented the `usePushNotifications` React hook to encapsulate logic for checking support, subscription status, permissions, and handling subscribe/unsubscribe actions.

**Web Push Subscription Logic:**

* Added utility functions in `lib/webPush.ts` for subscribing and unsubscribing to push notifications, including VAPID key handling and server communication for storing/removing subscriptions.