### PR TITLE
feat: Add cron job for dispatching push reminders and implement authorization handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,3 +42,6 @@ password=
 # Generate using: npx web-push generate-vapid-keys
 NEXT_PUBLIC_VAPID_PUBLIC_KEY=
 VAPID_PRIVATE_KEY=
+
+# --- Cron Auth ---
+CRON_SECRET=

--- a/.github/workflows/push-reminders.yml
+++ b/.github/workflows/push-reminders.yml
@@ -1,0 +1,16 @@
+name: Dispatch Push Reminders
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Push Reminders Cron
+        run: |
+          curl -s -X GET "https://[YOUR-PRODUCTION-URL]/api/cron/reminders" \
+            -H "Authorization: Bearer ${{ secrets.CRON_SECRET }}" \
+            --fail

--- a/app/api/cron/reminders/route.ts
+++ b/app/api/cron/reminders/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse, NextRequest } from "next/server";
+import webpush from "web-push";
+import { connectDB } from "@/lib/db";
+import PushSubscription from "@/models/PushSubscription";
+
+webpush.setVapidDetails(
+  "mailto:your-email@example.com",
+  process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY!,
+  process.env.VAPID_PRIVATE_KEY!
+);
+
+export async function GET(request: NextRequest) {
+  const authHeader = request.headers.get("authorization");
+  if (!authHeader || authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+    return new NextResponse(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  await connectDB();
+
+  try {
+    const subscriptions = await PushSubscription.find({});
+
+    const sendPromises = subscriptions.map(async (sub) => {
+      const pushSubscription = {
+        endpoint: sub.endpoint,
+        keys: {
+          p256dh: sub.p256dh,
+          auth: sub.auth,
+        },
+      };
+
+      try {
+        await webpush.sendNotification(
+          pushSubscription,
+          JSON.stringify({
+            title: "VeyrFlow",
+            body: "Time to check your habits!",
+          })
+        );
+      } catch (error: any) {
+        // Prune expired or invalid subscriptions
+        if (error.statusCode === 410 || error.statusCode === 404) {
+          await PushSubscription.deleteOne({ _id: sub._id });
+          console.log(`Pruned inactive subscription: ${sub.endpoint}`);
+        } else {
+          console.error(`Failed to send notification to ${sub.endpoint}:`, error);
+        }
+      }
+    });
+
+    await Promise.allSettled(sendPromises);
+
+    return NextResponse.json({ success: true, dispatchedCount: subscriptions.length });
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+}

--- a/app/api/cron/reminders/route.ts
+++ b/app/api/cron/reminders/route.ts
@@ -3,13 +3,16 @@ import webpush from "web-push";
 import { connectDB } from "@/lib/db";
 import PushSubscription from "@/models/PushSubscription";
 
-webpush.setVapidDetails(
-  "mailto:your-email@example.com",
-  process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY!,
-  process.env.VAPID_PRIVATE_KEY!
-);
+export const dynamic = "force-dynamic";
 
 export async function GET(request: NextRequest) {
+  // Configure webpush details inside the handler to prevent build-time errors when VAPID keys are missing
+  webpush.setVapidDetails(
+    "mailto:your-email@example.com",
+    process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY!,
+    process.env.VAPID_PRIVATE_KEY!
+  );
+
   const authHeader = request.headers.get("authorization");
   if (!authHeader || authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
     return new NextResponse(JSON.stringify({ error: "Unauthorized" }), {


### PR DESCRIPTION
This pull request introduces a scheduled push notification system for user habit reminders, including secure authentication for the cron endpoint and automated pruning of expired push subscriptions. The main changes are grouped below by theme:

**Scheduled Push Notification System:**

* Added a new API route `app/api/cron/reminders/route.ts` that sends web push notifications to all saved user subscriptions, reminding users to check their habits. The route also removes expired or invalid subscriptions automatically.

* Created a new GitHub Actions workflow `.github/workflows/push-reminders.yml` to trigger the push reminders endpoint every 15 minutes using a secure token.

**Security and Configuration:**

* Added a `CRON_SECRET` environment variable to `.env.example` for authenticating scheduled requests to the reminders API endpoint.