### PR TITLE
Add '/api/cron/reminders' to public route matcher in proxy middleware

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -1,6 +1,12 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 
-const isPublicRoute = createRouteMatcher(["/", "/sign-in(.*)", "/sign-up(.*)", "/docs(.*)"]);
+const isPublicRoute = createRouteMatcher([
+  "/",
+  "/sign-in(.*)",
+  "/sign-up(.*)",
+  "/docs(.*)",
+  "/api/cron/reminders",
+]);
 
 export default clerkMiddleware(async (auth, req) => {
   if (!isPublicRoute(req)) {


### PR DESCRIPTION
This pull request updates the route matching logic in the `proxy.ts` file to treat the `/api/cron/reminders` endpoint as a public route. This means authentication will not be required for requests to this endpoint.

- Routing update:
  * Added `/api/cron/reminders` to the list of public routes in the `isPublicRoute` matcher, allowing unauthenticated access to this endpoint.