### PR TITLE
Remove unused variable in calculateStreak function

### DIFF
--- a/lib/utils/date.ts
+++ b/lib/utils/date.ts
@@ -29,7 +29,7 @@ export function calculateStreak(completedDates: string[], todayStr: string): num
   const sorted = [...new Set(completedDates)].sort((a, b) => a.localeCompare(b));
   
   let currentStreak = 0;
-  let lastCheckedDate = "";
+  // let lastCheckedDate = "";
 
   // The logic: iterate backwards from the latest date.
   // If the latest date is TODAY or YESTERDAY, the streak is alive.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "veyrflow",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@11.3.0",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
This pull request introduces two minor updates: one to the project configuration and another as a small code cleanup in a utility function.

- Project configuration:
  * Added the `packageManager` field specifying `pnpm@11.3.0` to `package.json` for consistent dependency management.

- Code cleanup:
  * Commented out the unused `lastCheckedDate` variable in the `calculateStreak` function in `lib/utils/date.ts` to tidy up the code.